### PR TITLE
initialize project after ctx and DOM are defined

### DIFF
--- a/banana_pixel_index.html
+++ b/banana_pixel_index.html
@@ -341,7 +341,6 @@
       saveHistory();
       drawComposite();
     }
-    initProject();
 
     /**********************
      * Canvas & Composite Rendering
@@ -916,6 +915,9 @@
       if (e.key === 'y') { symmetryMode = !symmetryMode; symmetryBtn.classList.toggle('active', symmetryMode); }
     });
 
+    // Ensure project is initialized after ctx and DOM are defined
+    initProject();
+    
     // Initial draw
     drawComposite();
   </script>


### PR DESCRIPTION
Ensures that the project is only initialized after all its dependencies are defined (layersList, framesList, ctx)