### PR TITLE
Disable Default Mobile Touch Behaviors on Canvas

### DIFF
--- a/banana_pixel_index.html
+++ b/banana_pixel_index.html
@@ -96,13 +96,26 @@
       justify-content: space-between;
       color: #222;
     }
-    #main { 
+    #main, #compositeCanvas { 
       grid-area: main; 
       background: #fff; 
       display: flex; 
       align-items: center; 
       justify-content: center; 
       padding: 20px;
+          
+      /* Disable text selection */
+      -webkit-user-select: none; /* Chrome, Safari, Opera */
+      -moz-user-select: none;    /* Firefox */
+      -ms-user-select: none;     /* IE/Edge */
+      user-select: none;         /* Standard */
+      /* Disable touch gestures such as double-tap to zoom */
+      touch-action: none;
+      /* Optional: Disable tap highlight color on mobile browsers */
+      -webkit-tap-highlight-color: transparent;
+      /* Optional: Disable callouts (iOS) */
+      -webkit-touch-callout: none;
+      
     }
     #timeline { 
       grid-area: timeline; 


### PR DESCRIPTION
This PR updates the CSS for the #main and #compositeCanvas selectors to disable default browser behaviors on mobile devices that interfere with the drawing experience. With these changes, users will no longer encounter unwanted text selection, double-tap zoom, tap highlights, or iOS callouts when interacting with the canvas. This results in a smoother and more intuitive single-tap drawing experience.

Changes Introduced:

Text Selection Disabled: Prevents accidental text highlighting by setting user-select to none (with vendor prefixes for broader browser support).

Touch Gestures Disabled: Uses touch-action: none to disable default touch gestures such as double-tap zoom.

Tap Highlight Removed: Eliminates the tap highlight color on mobile browsers via -webkit-tap-highlight-color: transparent.

iOS Callouts Disabled: Disables default callout actions using -webkit-touch-callout: none.